### PR TITLE
Memory leak on unmatched nodes texts

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ If set to true, the xpath-ish query will be case-insensitive. Non-strict mode en
 If the callback function accepts a done callback, then xml will be processed *chunk* characters at a time. So, there will be a short flood of match callbacks and the xml processor will wait until all of the callbacks are complete before releasing the next chunk. This is convenient for processing very large xml files with callbacks that do a lot of I/O. Instead of firing and queuing tons of callbacks while the rest of xml processing uses the cpu, the xml processor yields control until all of the callbacks are done for each chunk.
 
 ### freeUnmatchedNodes
-**default: false**
+**default: true**
 
-If set to true, the text event of sax parser will check if the node is in the matcher xpath or lower. If it is not it will not store text. This behavior is slow and CPU consuming, but more memory effective. Turn it on for large XMLs with line-breaks between nodes in low-RAM environments.
+If set to true, the text event of sax parser will check if the node is in the matcher xpath or lower. If it is not it will not store text. This behavior is slower and CPU consuming, but more memory effective. Turn it off if you know what you're doing.
 
 ## Arguments
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ If set to true, the xpath-ish query will be case-insensitive. Non-strict mode en
 
 If the callback function accepts a done callback, then xml will be processed *chunk* characters at a time. So, there will be a short flood of match callbacks and the xml processor will wait until all of the callbacks are complete before releasing the next chunk. This is convenient for processing very large xml files with callbacks that do a lot of I/O. Instead of firing and queuing tons of callbacks while the rest of xml processing uses the cpu, the xml processor yields control until all of the callbacks are done for each chunk.
 
+### freeUnmatchedNodes
+**default: false**
+
+If set to true, the text event of sax parser will check if the node is in the matcher xpath or lower. If it is not it will not store text. This behavior is slow and CPU consuming, but more memory effective. Turn it on for large XMLs with line-breaks between nodes in low-RAM environments.
+
 ## Arguments
 
 function(xml, xpath[, callback]);

--- a/index.js
+++ b/index.js
@@ -228,15 +228,20 @@ module.exports = function(config) {
     stream.on('text', function(txt) {
       var n = current();
       //console.log(txt, n);
-      if(!freeUnmatchedNodes || matches()){
+      if(freeUnmatchedNodes){
         // add text to current
         if (!!n) {
-          if (!n.text) n.text = txt;
-          else n.text += txt;
+          if(matches()) {
+            if (!n.text) n.text = txt;
+            else n.text += txt;
+          }else{
+            n.text = '';
+          }
         }
       }else{
-        if (!!n) {
-          n.text = '';
+        if(!!n){
+          if (!n.text) n.text = txt;
+          else n.text += txt;
         }
       }
     });

--- a/index.js
+++ b/index.js
@@ -99,7 +99,7 @@ module.exports = function(config) {
       icase = cfg.icase || true,
       pojo = cfg.pojo || false,
       chunkSize = cfg.chunk || 8196,
-      freeUnmatchedNodes = cfg.freeUnmatchedNodes || false;
+      freeUnmatchedNodes = cfg.hasOwnProperty('freeUnmatchedNodes')?cfg.freeUnmatchedNodes:true;
 
   return function(xml, pattern, cb) {
     var stream = sax.createStream(strict, cfg);
@@ -149,17 +149,14 @@ module.exports = function(config) {
     function matches(){
       var matched = false;
       var locm = '/' + path.join('/');
-      //console.log(locm);
       // is this a node or a child node of node we're looking for?
       for (var i = 0; i < Math.max(matcher.length,childMatcher.length); i++) {
         if (!!locm.match(matcher[i]) || !!locm.match(childMatcher[i])) {
-          //console.log(i,matcher[i],childMatcher[i]);
           matched = true;
           // make sure we don't match more than one pattern
           break;
         }
       }
-      //console.log(matched);
       return matched;
     }
 
@@ -227,7 +224,6 @@ module.exports = function(config) {
 
     stream.on('text', function(txt) {
       var n = current();
-      //console.log(txt, n);
       if(freeUnmatchedNodes){
         // add text to current
         if (!!n) {

--- a/index.js
+++ b/index.js
@@ -147,18 +147,20 @@ module.exports = function(config) {
     }
 
     function matches(){
-      var matches = false;
-      var loc = '/' + path.join('/');
+      var matched = false;
+      var locm = '/' + path.join('/');
+      //console.log(locm);
       // is this a node or a child node of node we're looking for?
-      for (i = 0; i < matcher.length; i++) {
-        if (!!loc.match(matcher[i]) || !!loc.match(childMatcher[i])) {
-          matches = true;
+      for (var i = 0; i < Math.max(matcher.length,childMatcher.length); i++) {
+        if (!!locm.match(matcher[i]) || !!locm.match(childMatcher[i])) {
+          //console.log(i,matcher[i],childMatcher[i]);
+          matched = true;
           // make sure we don't match more than one pattern
           break;
         }
       }
-
-      return matches;
+      //console.log(matched);
+      return matched;
     }
 
     if (!cb) {
@@ -224,14 +226,18 @@ module.exports = function(config) {
     });
 
     stream.on('text', function(txt) {
-      if(freeUnmatchedNodes){
-        if(!matches()) return;
-      }
-      // add text to current
       var n = current();
-      if (!!n) {
-        if (!n.text) n.text = txt;
-        else n.text += txt;
+      //console.log(txt, n);
+      if(!freeUnmatchedNodes || matches()){
+        // add text to current
+        if (!!n) {
+          if (!n.text) n.text = txt;
+          else n.text += txt;
+        }
+      }else{
+        if (!!n) {
+          n.text = '';
+        }
       }
     });
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,6 @@
     "should": "^3"
   },
   "scripts": {
-    "test": "node_modules/.bin/mocha -R spec ./test"
+    "test": "node_modules/.bin/mocha --expose-gc -R spec ./test"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -35,6 +35,18 @@ describe('XML Stream', function() {
       });
     });
 
+    it('should fire the callback for matched nodes with freeUnmatchedNodes', function(done) {
+      var xos = xoss({ pojo: true , freeUnmatchedNodes: true});
+      var count = 0;
+      xos(xml, '//book', function(b) {
+        count++;
+        if (count === 1) b.pages.should.equal('411');
+        if (count === 2) b.pages.should.equal('8812');
+        if (count === 3) b.pages.should.equal('41');
+        if (count === 3) done();
+      });
+    });
+
     it('should be cool with chunking too', function(done) {
       var xos = xoss({ pojo: true, chunk: 32 });
       var count = 0;
@@ -46,6 +58,19 @@ describe('XML Stream', function() {
         if (count === 3) done();
       });
     });
+
+    it('should be cool with chunking too with freeUnmatchedNodes', function(done) {
+      var xos = xoss({ pojo: true, chunk: 32, freeUnmatchedNodes: true });
+      var count = 0;
+      xos(xml, '//book', function(b) {
+        count++;
+        if (count === 1) b.pages.should.equal('411');
+        if (count === 2) b.pages.should.equal('8812');
+        if (count === 3) b.pages.should.equal('41');
+        if (count === 3) done();
+      });
+    });
+
   });
 
   describe('xml as a string', function() {
@@ -77,6 +102,14 @@ describe('XML Stream', function() {
         }, done);
       });
 
+      it('should process all queries in an array with freeUnmatchedNodes', function(done) {
+        var xos = xoss({freeUnmatchedNodes: true});
+        xos(xml, ['/library/shelf', '/library/section/shelf']).then(function(s) {
+          s.length.should.equal(3);
+          done();
+        }, done);
+      });
+
       it('should only match each node at most once', function(done) {
         var xos = xoss();
         xos(xml, ['/library/shelf', '//shelf', '/library/section/shelf']).then(function(s) {
@@ -84,6 +117,15 @@ describe('XML Stream', function() {
           done();
         }, done);
       });
+
+      it('should only match each node at most once with freeUnmatchedNodes', function(done) {
+        var xos = xoss({freeUnmatchedNodes: true});
+        xos(xml, ['/library/shelf', '//shelf', '/library/section/shelf']).then(function(s) {
+          s.length.should.equal(3);
+          done();
+        }, done);
+      });
+
     });
   });
 });

--- a/test/index.js
+++ b/test/index.js
@@ -154,12 +154,10 @@ describe('XML Stream', function() {
 
       MyStream.prototype._read = function(n) {
         var self = this;
-        //console.log('read',n,this.counter,self.counter,this.proceeding);
         if (!this.headPushed) {
           this.push('<library><shelf>123</shelf>');
           this.headPushed = true;
         } else {
-          //setTimeout(function () {
           if(self.proceeding && self.counter > 1){
             self.push(leakdata);
           }
@@ -176,7 +174,6 @@ describe('XML Stream', function() {
               self.push(null);
             }
           }
-          //},3);
         }
       };
 
@@ -213,12 +210,10 @@ describe('XML Stream', function() {
 
       MyStream.prototype._read = function(n) {
         var self = this;
-        //console.log('read',n,this.counter,self.counter,this.proceeding);
         if (!this.headPushed) {
           this.push('<library><shelf>123</shelf>');
           this.headPushed = true;
         } else {
-          //setTimeout(function () {
           if(self.proceeding && self.counter > 1){
             self.push(leakdata);
           }
@@ -235,7 +230,6 @@ describe('XML Stream', function() {
               self.push(null);
             }
           }
-          //},3);
         }
       };
 

--- a/test/index.js
+++ b/test/index.js
@@ -129,107 +129,126 @@ describe('XML Stream', function() {
       });
 
     });
+  });
+  describe('freeUnmatchedNodes memory leak', function(){
 
-    describe('freeUnmatchedNodes memory leak', function(){
-      it('set to false should leak', function(done) {
-        this.timeout(10000);
-        var iterations = 1500;
-        var leakdata = 'AAAAAAAAAA';
-        var xos = xoss({freeUnmatchedNodes: false});
-        var oldMem = process.memoryUsage();
-        var newMem;
-        var MyStream = function(options) {
-          Readable.call(this, options); // pass through the options to the Readable constructor
-          this.headPushed = false;
-          this.counter = iterations;
-          this.proceeding = true;
-        };
+    it('set to true should not leak', function(done) {
+      this.timeout(10000);
+      var iterations = 4000;
+      var leakdata = 'AAAAAAAAAA'.repeat(4096);
+      var xos = xoss({freeUnmatchedNodes: true});
+      var oldMem;
+      var newMem;
 
-        util.inherits(MyStream, Readable); // inherit the prototype methods
+      global.gc();
+      oldMem = process.memoryUsage();
 
-        MyStream.prototype._read = function(n) {
-          var self = this;
-          //console.log('read',n,this.counter,self.counter);
-          if (!this.headPushed) {
-            this.push('<library><shelf>123</shelf>');
-            this.headPushed = true;
-          } else {
-            setTimeout(function () {
-              if(self.proceeding)self.push(leakdata);
-              if(self.counter === 1){
-                newMem = process.memoryUsage();
-                if(self.proceeding)self.push('</library>');
-              }
-              if (self.counter-- <= 0) { // stop the stream
-                if(self.proceeding){
-                  self.proceeding = false;
-                  self.push(null);
-                  self.emit('end');
-                }
-              }
-            },1);
+      var MyStream = function(options) {
+        Readable.call(this, options); // pass through the options to the Readable constructor
+        this.headPushed = false;
+        this.counter = iterations;
+        this.proceeding = true;
+      };
+
+      util.inherits(MyStream, Readable); // inherit the prototype methods
+
+      MyStream.prototype._read = function(n) {
+        var self = this;
+        //console.log('read',n,this.counter,self.counter,this.proceeding);
+        if (!this.headPushed) {
+          this.push('<library><shelf>123</shelf>');
+          this.headPushed = true;
+        } else {
+          //setTimeout(function () {
+          if(self.proceeding && self.counter > 1){
+            self.push(leakdata);
           }
-        };
-
-        var xmlFeeder = new MyStream();
-        xos(xmlFeeder, ['/library/shelf']).then(function(s) {
-          newMem.heapTotal.should.be.above(oldMem.heapTotal + leakdata.length*iterations);
-          newMem.heapUsed.should.be.above(oldMem.heapUsed + leakdata.length*iterations);
-          done();
-        }, done);
-        xmlFeeder.emit('readable');
-      });
-
-      it('set to true should not leak', function(done) {
-        this.timeout(10000);
-        var iterations = 1500;
-        var leakdata = 'AAAAAAAAAA';
-        var xos = xoss({freeUnmatchedNodes: true});
-        var oldMem = process.memoryUsage();
-        var newMem;
-        var MyStream = function(options) {
-          Readable.call(this, options); // pass through the options to the Readable constructor
-          this.headPushed = false;
-          this.counter = iterations;
-          this.proceeding = true;
-        };
-
-        util.inherits(MyStream, Readable); // inherit the prototype methods
-
-        MyStream.prototype._read = function(n) {
-          var self = this;
-          //console.log('read',n,this.counter,self.counter,this.proceeding);
-          if (!this.headPushed) {
-            this.push('<library><shelf>123</shelf>');
-            this.headPushed = true;
-          } else {
-            //setTimeout(function () {
-            if(self.proceeding)self.push(leakdata);
-            if(self.counter === 1){
-              newMem = process.memoryUsage();
-              if(self.proceeding)self.push('</library>');
+          if(self.counter === 1){
+            global.gc();
+            newMem = process.memoryUsage();
+            if(self.proceeding){
+              self.push('</library>');
             }
-            if (self.counter-- === 0) { // stop the stream
-              if(self.proceeding){
-                self.proceeding = false;
-                self.push(null);
-                self.emit('end');
-              }
-            }
-            //},1);
           }
-        };
+          if (self.counter-- <= 0) { // stop the stream
+            if(self.proceeding){
+              self.proceeding = false;
+              self.push(null);
+            }
+          }
+          //},3);
+        }
+      };
 
-        var xmlFeeder = new MyStream();
-        xos(xmlFeeder, ['/library/shelf']).then(function(s) {
-          //console.log(s);
-          newMem.heapTotal.should.be.below(oldMem.heapTotal + leakdata.length*iterations);
-          newMem.heapUsed.should.be.below(oldMem.heapUsed + leakdata.length*iterations);
+      var xmlFeeder = new MyStream();
+      xos(xmlFeeder, ['/library/shelf']).then(function(s) {
+        try {
+          newMem.heapTotal.should.be.belowOrEqual(oldMem.heapTotal + leakdata.length*iterations, 'heapTotal');
+          newMem.heapUsed.should.be.belowOrEqual(oldMem.heapUsed + leakdata.length*iterations, 'heapUsed');
           done();
-        }, done);
-        xmlFeeder.emit('readable');
-      });
+        }catch (e) {
+          done(e);
+        }
+      }, done);
     });
 
+    it('set to false should leak', function(done) {
+      this.timeout(10000);
+      var iterations = 4000;
+      var leakdata = 'AAAAAAAAAA'.repeat(4096);
+      var xos = xoss({freeUnmatchedNodes: false});
+      var oldMem;
+      var newMem;
+
+      global.gc();
+      oldMem = process.memoryUsage();
+      var MyStream = function(options) {
+        Readable.call(this, options); // pass through the options to the Readable constructor
+        this.headPushed = false;
+        this.counter = iterations;
+        this.proceeding = true;
+      };
+
+      util.inherits(MyStream, Readable); // inherit the prototype methods
+
+      MyStream.prototype._read = function(n) {
+        var self = this;
+        //console.log('read',n,this.counter,self.counter,this.proceeding);
+        if (!this.headPushed) {
+          this.push('<library><shelf>123</shelf>');
+          this.headPushed = true;
+        } else {
+          //setTimeout(function () {
+          if(self.proceeding && self.counter > 1){
+            self.push(leakdata);
+          }
+          if(self.counter === 1){
+            global.gc();
+            newMem = process.memoryUsage();
+            if(self.proceeding){
+              self.push('</library>');
+            }
+          }
+          if (self.counter-- <= 0) { // stop the stream
+            if(self.proceeding){
+              self.proceeding = false;
+              self.push(null);
+            }
+          }
+          //},3);
+        }
+      };
+
+      var xmlFeeder = new MyStream();
+      xos(xmlFeeder, ['/library/shelf']).then(function(s) {
+        try {
+          newMem.heapTotal.should.be.aboveOrEqual(oldMem.heapTotal + leakdata.length*iterations, 'heapTotal');
+          newMem.heapUsed.should.be.above(oldMem.heapUsed + leakdata.length*iterations, 'heapUsed');
+          done();
+        }catch (e) {
+          done(e);
+        }
+      }, done);
+    });
   });
 });


### PR DESCRIPTION
I have a 37Gb XML with line-breaks in between of 7,000,000 nodes I need to match and a 8Gb RAM machine for this processing. Over time the line-breaks gather in a huge linked list of one-character strings that allocate at least 40 bytes per each. And the total memory usage goes out of control.

This PR introduces non-leaking behavior  set as default, tests for the leaking/non-leaking behavior, updates dev dependencies.
