### PR TITLE
Invert match - alt for #2

### DIFF
--- a/index.js
+++ b/index.js
@@ -106,7 +106,6 @@ module.exports = function(config) {
     var path = [];
     var matcher = [];
     var levels = [];
-    var childMatcher = [];
     var defer;
     var promise;
     var after;
@@ -114,13 +113,9 @@ module.exports = function(config) {
 
     if (typeof pattern === 'string') {
       matcher.push(new RegExp('^' + pattern.replace(/\/\//, '\\/.*?') + '$', icase || !strict ? 'i' : ''));
-      childMatcher.push(new RegExp('^' + pattern.replace(/\/\//, '\\/.*?') + '/', icase || !strict ? 'i' : ''));
     } else if (Array.isArray(pattern)) {
       for (var i = 0; i < pattern.length; i++) {
-        var pat = pattern[i];
-
-        matcher.push(new RegExp('^' + pat.replace(/\/\//, '\\/.*?') + '$', icase || !strict ? 'i' : ''));
-        childMatcher.push(new RegExp('^' + pat.replace(/\/\//, '\\/.*?') + '/', icase || !strict ? 'i' : ''));
+        matcher.push(new RegExp('^' + pattern[i].replace(/\/\//, '\\/.*?') + '$', icase || !strict ? 'i' : ''));
       }
     } else throw 'Invalid pattern.';
 

--- a/index.js
+++ b/index.js
@@ -151,11 +151,6 @@ module.exports = function(config) {
       });
     } else after = { onEnd: function(fn) { after.callback = fn; } };
 
-    function current() {
-      if (stack.length > 0) return stack[stack.length - 1];
-      else return null;
-    }
-
     stream.on('error', function(e) {
       this._parser.error = null;
       this._parser.resume();
@@ -165,14 +160,14 @@ module.exports = function(config) {
       // keep path current
       path.push(node.name);
 
-      stack.push(node);
+      stack.unshift(node);
     });
 
     stream.on('closetag', function(name) {
       var loc = '/' + path.join('/');
       path.pop();
-      var n = pojo ? { object: buildPojo(stack.pop()), name: name } : build(stack.pop());
-      var p = current();
+      var n = pojo ? { object: buildPojo(stack.shift()), name: name } : build(stack.shift());
+      var p = stack[0];
       var i;
 
       // is this a child of a node we're looking for?
@@ -209,7 +204,7 @@ module.exports = function(config) {
 
     stream.on('text', function(txt) {
       // add text to current
-      var n = current();
+      var n = stack[0];
       if (!!n) {
         if (!n.text) n.text = txt;
         else n.text += txt;

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
   },
   "devDependencies": {
     "mocha": "^1",
-    "should": "^3"
+    "should": "^8"
   },
   "scripts": {
-    "test": "node_modules/.bin/mocha -R spec ./test"
+    "test": "node_modules/.bin/mocha --expose-gc -R spec ./test"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -86,4 +86,20 @@ describe('XML Stream', function() {
       });
     });
   });
+
+  describe('matching', function() {
+    it('should gather children on matched nodes', function(done) {
+      var count = 0;
+      var xos = xoss({ pojo: true });
+      xos(xml, '//shelf', function(shelf) {
+        if (count === 0) shelf.id.should.equal('returns');
+        else if (count === 1) shelf.book.length.should.equal(2);
+        else if (count === 2) shelf.book.contents.chapter.length.should.equal(3);
+        count++;
+      }).onEnd(function() {
+        count.should.equal(3);
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
Move matching to the open tag event so that text on non-matching nodes can be discarded. This is a potential alternate fix for #2.
